### PR TITLE
Align formatting of GOVERNANCE.md

### DIFF
--- a/project-docs/GOVERNANCE.md
+++ b/project-docs/GOVERNANCE.md
@@ -20,13 +20,13 @@ This project may include the following roles. Additional roles may be adopted an
 
 **3.1. Openness**. Participation is open to anyone who is directly and materially affected by the activity in question. There shall be no undue financial barriers to participation.
 
-**3.2. Balance.**  The development process should balance the interests of Contributors and other stakeholders. Contributors from diverse interest categories shall be sought with the objective of achieving balance.
+**3.2. Balance**. The development process should balance the interests of Contributors and other stakeholders. Contributors from diverse interest categories shall be sought with the objective of achieving balance.
 
-**3.3. Coordination and Harmonization.** Good faith efforts shall be made to resolve potential conflicts or incompatibility between releases in this Project.
+**3.3. Coordination and Harmonization**. Good faith efforts shall be made to resolve potential conflicts or incompatibility between releases in this Project.
 
-**3.4. Consideration of Views and Objections.** Prompt consideration shall be given to the written views and objections of all Contributors.
+**3.4. Consideration of Views and Objections**. Prompt consideration shall be given to the written views and objections of all Contributors.
 
-**3.5. Written procedures.** This governance document and other materials documenting this project's development process shall be available to any interested person.
+**3.5. Written procedures**. This governance document and other materials documenting this project's development process shall be available to any interested person.
 
 ## 4. No Confidentiality.
 

--- a/project-docs/GOVERNANCE.md
+++ b/project-docs/GOVERNANCE.md
@@ -2,31 +2,31 @@
 
 This document provides the governance policy for the Project. Maintainers agree to this policy and to abide by all Project polices, including the code of conduct, trademark policy, and antitrust policy by adding their name to the maintainers.md file.
 
-## 1.	Roles.
+## 1. Roles.
 
 This project may include the following roles. Additional roles may be adopted and documented by the Project.
 
-**1.1.	Maintainers**. Maintainers are responsible for organizing activities around developing, maintaining, and updating the Project. Maintainers are also responsible for determining consensus. This Project may add or remove Maintainers with the approval of the current Maintainers.
+**1.1. Maintainers**. Maintainers are responsible for organizing activities around developing, maintaining, and updating the Project. Maintainers are also responsible for determining consensus. This Project may add or remove Maintainers with the approval of the current Maintainers.
 
-**1.2.	Contributors**. Contributors are those that have made contributions to the Project.
+**1.2. Contributors**. Contributors are those that have made contributions to the Project.
 
-## 2.	Decisions.
+## 2. Decisions.
 
-**2.1.	Consensus-Based Decision Making**. Projects make decisions through consensus of the Maintainers. While explicit agreement of all Maintainers is preferred, it is not required for consensus. Rather, the Maintainers will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the Contributors and nature of support and objections. The Maintainers will document evidence of consensus in accordance with these requirements.
+**2.1. Consensus-Based Decision Making**. Projects make decisions through consensus of the Maintainers. While explicit agreement of all Maintainers is preferred, it is not required for consensus. Rather, the Maintainers will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the Contributors and nature of support and objections. The Maintainers will document evidence of consensus in accordance with these requirements.
 
-**2.2.	Appeal Process**. Decisions may be appealed by opening an issue and that appeal will be considered by the Maintainers in good faith, who will respond in writing within a reasonable time. If the Maintainers deny the appeal, the appeal my be brought before the Organization Steering Committee, who will also respond in writing in a reasonable time.
+**2.2. Appeal Process**. Decisions may be appealed by opening an issue and that appeal will be considered by the Maintainers in good faith, who will respond in writing within a reasonable time. If the Maintainers deny the appeal, the appeal my be brought before the Organization Steering Committee, who will also respond in writing in a reasonable time.
 
-## 3.	How We Work.
+## 3. How We Work.
 
-**3.1.	Openness**. Participation is open to anyone who is directly and materially affected by the activity in question. There shall be no undue financial barriers to participation.
+**3.1. Openness**. Participation is open to anyone who is directly and materially affected by the activity in question. There shall be no undue financial barriers to participation.
 
-**3.2.	Balance.**  The development process should balance the interests of Contributors and other stakeholders. Contributors from diverse interest categories shall be sought with the objective of achieving balance.
+**3.2. Balance.**  The development process should balance the interests of Contributors and other stakeholders. Contributors from diverse interest categories shall be sought with the objective of achieving balance.
 
-**3.3.	Coordination and Harmonization.** Good faith efforts shall be made to resolve potential conflicts or incompatibility between releases in this Project.
+**3.3. Coordination and Harmonization.** Good faith efforts shall be made to resolve potential conflicts or incompatibility between releases in this Project.
 
-**3.4.	Consideration of Views and Objections.** Prompt consideration shall be given to the written views and objections of all Contributors.
+**3.4. Consideration of Views and Objections.** Prompt consideration shall be given to the written views and objections of all Contributors.
 
-**3.5.	Written procedures.** This governance document and other materials documenting this project's development process shall be available to any interested person.
+**3.5. Written procedures.** This governance document and other materials documenting this project's development process shall be available to any interested person.
 
 ## 4. No Confidentiality.
 


### PR DESCRIPTION
Removing tabs in favor of spaces for main bullets. 
(oh no, tabs vs spaces again? :))

This PR makes the format in `GOVERNANCE.md` the same as in `CHARTER.md`.

Also fixes some inconsistent periods after sub-bullets
i.e. `**3.2. Balance**.` rather than `**3.2. Balance.**`

Likely not the most important thing to fix but I saw it, so I figured why not :)